### PR TITLE
Fix race condition

### DIFF
--- a/UrsinaLighting.py
+++ b/UrsinaLighting.py
@@ -37,6 +37,7 @@ class LitObject(Entity):
             scale = scale,
             texture = texture,
             color = color,
+            enabled = False,
         )
 
         for key, value in kwargs.items():
@@ -59,6 +60,8 @@ class LitObject(Entity):
         self.set_shader_input("cubemap", cubemaps)
         self.set_shader_input("cubemapIntensity", cubemapIntensity)
         self.onUpdate = onUpdate
+
+        self.enabled = True
     
     def update(self):
         self.set_shader_input("lightsArray", LitLightList)


### PR DESCRIPTION
In ursina, the definitions that come after calling super().__init__() may cause the update() function to be called before the definitions are actually set, the disabled-enabled switch makes sure the update function is not called until all variables are defined. Love your work btw!